### PR TITLE
Go to start/end of line

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -110,9 +110,9 @@ static struct editorConfig E;
 
 enum KEY_ACTION {
     CTRL_A = 1, CTRL_C = 3, CTRL_D = 4, CTRL_E = 5, CTRL_F = 6, BACKSPACE = 127, TAB = 9,
-    CTRL_K = 11, CTRL_L = 12, ENTER = 13, CTRL_N = 14, CTRL_P = 16, CTRL_Q = 17, CTRL_R = 18,
-    CTRL_S = 19, CTRL_U = 21, CTRL_X = 24, CTRL_Y = 25, CTRL_Z = 26, ESC = 27, FORWARD_DELETE =  127,
-    CTRL_H = 8,
+    CTRL_J = 10, CTRL_K = 11, CTRL_L = 12, ENTER = 13, CTRL_N = 14, CTRL_P = 16, CTRL_Q = 17, 
+    CTRL_R = 18, CTRL_S = 19, CTRL_U = 21, CTRL_X = 24, CTRL_Y = 25, CTRL_Z = 26, ESC = 27, 
+    FORWARD_DELETE =  127, CTRL_H = 8,
     // The following are just soft codes, not really reported by the
     // terminal directly.
     ARROW_LEFT = 1000, ARROW_RIGHT, ARROW_UP, ARROW_DOWN, DEL_KEY, HOME_KEY,
@@ -1150,6 +1150,12 @@ void editorMoveCursor(int key) {
             }
         }
         break;
+    case CTRL_J:
+        E.cx = 0;
+        break;
+    case CTRL_K:
+        E.cx = E.screencols-1;
+        break;
     }
     /* Fix cx if the current line has not enough chars. */
     filerow = E.rowoff+E.cy;
@@ -1222,6 +1228,8 @@ void editorProcessKeypress(int fd) {
     case ARROW_DOWN:
     case ARROW_LEFT:
     case ARROW_RIGHT:
+    case CTRL_J:
+    case CTRL_K:
     case CTRL_U:
     case CTRL_D:
     case CTRL_L:


### PR DESCRIPTION
Sorry for the confusion and thanks for the patience.
Added switch cases for Ctrl-J (move to start) and Ctrl-K (move to end), ASCII code 10, 11 respectively