### PR TITLE
Add java syntax and dynamic resize

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -50,6 +50,7 @@
 #include <unistd.h>
 #include <stdarg.h>
 #include <fcntl.h>
+#include <signal.h>
 
 /* Syntax highlight types */
 #define HL_NORMAL 0
@@ -153,7 +154,7 @@ char *C_HL_keywords[] = {
         "void|","uint32_t|","uint64_t|",NULL
 };
 
-/* python */
+/* Python */
 char *PY_HL_extensions[] = {".py","python",NULL};
 char *PY_HL_keywords[] = {
        "def","if","while","for","break","return","continue","else","elif",
@@ -167,6 +168,19 @@ char *PY_HL_keywords[] = {
        "oct|","complex|",NULL
 };
 
+/* Java */
+char *J_HL_extensions[] = {".java",NULL};
+char *J_HL_keywords[] = {
+        "abstract","assert","break","case","catch","class","const","continue",
+        "default","do","else","enum","extends","final","finally","for","goto",
+        "if","implements","import","instanceof","interface","native","new",
+        "package","private","protected","public","return","static","strictfp",
+        "super","switch","synchronized","this","throw","throws","transient",
+        "try","void","volatile","while",
+        /* Java types */
+        "boolean|","byte|","char|","double|","float|","int|","long|","short|",NULL
+};
+
 /* Here we define an array of syntax highlights by extensions, keywords,
  * comments delimiters and flags. */
 struct editorSyntax HLDB[] = {
@@ -178,9 +192,17 @@ struct editorSyntax HLDB[] = {
         HL_HIGHLIGHT_STRINGS | HL_HIGHLIGHT_NUMBERS
     },
     {
+        /* Python */
         PY_HL_extensions,
         PY_HL_keywords,
         "#","\"\"\"", "\"\"\"",
+        HL_HIGHLIGHT_STRINGS | HL_HIGHLIGHT_NUMBERS
+    },
+    {
+        /* Java */
+        J_HL_extensions,
+        J_HL_keywords,
+        "//","/*","*/",
         HL_HIGHLIGHT_STRINGS | HL_HIGHLIGHT_NUMBERS
     }
 };
@@ -1270,6 +1292,12 @@ void initEditor(void) {
     E.screenrows -= 2; /* Get room for status bar. */
 }
 
+void resizeHandler() {
+    /* TEMPORARY FIX, NOT ASYNC-SAFE */
+    getWindowSize(STDIN_FILENO,STDOUT_FILENO, &E.screenrows,&E.screencols);
+    editorRefreshScreen();
+}
+
 int main(int argc, char **argv) {
     if (argc != 2) {
         fprintf(stderr,"Usage: kilo <filename>\n");
@@ -1282,6 +1310,9 @@ int main(int argc, char **argv) {
     enableRawMode(STDIN_FILENO);
     editorSetStatusMessage(
         "HELP: Ctrl-S = save | Ctrl-Q = quit | Ctrl-F = find");
+    
+    signal(SIGWINCH, resizeHandler);
+
     while(1) {
         editorRefreshScreen();
         editorProcessKeypress(STDIN_FILENO);

--- a/kilo.c
+++ b/kilo.c
@@ -108,33 +108,15 @@ struct editorConfig {
 
 static struct editorConfig E;
 
-enum KEY_ACTION{
-        KEY_NULL = 0,       /* NULL */
-        CTRL_C = 3,         /* Ctrl-c */
-        CTRL_D = 4,         /* Ctrl-d */
-        CTRL_F = 6,         /* Ctrl-f */
-        CTRL_H = 8,         /* Ctrl-h */
-        TAB    = 9,            /* Tab */
-        CTRL_J = 10,        /* Ctrl-j */
-        CTRL_K = 11,        /* Ctrl-k */
-        CTRL_L = 12,        /* Ctrl+l */
-        ENTER  = 13,         /* Enter */
-        CTRL_Q = 17,        /* Ctrl-q */
-        CTRL_S = 19,        /* Ctrl-s */
-        CTRL_U = 21,        /* Ctrl-u */
-        ESC = 27,           /* Escape */
-        BACKSPACE =  127,   /* Backspace */
-        /* The following are just soft codes, not really reported by the
-         * terminal directly. */
-        ARROW_LEFT = 1000,
-        ARROW_RIGHT,
-        ARROW_UP,
-        ARROW_DOWN,
-        DEL_KEY,
-        HOME_KEY,
-        END_KEY,
-        PAGE_UP,
-        PAGE_DOWN
+enum KEY_ACTION {
+    CTRL_A = 1, CTRL_C = 3, CTRL_D = 4, CTRL_E = 5, CTRL_F = 6, BACKSPACE = 127, TAB = 9,
+    CTRL_J = 10, CTRL_K = 11, CTRL_L = 12, ENTER = 13, CTRL_N = 14, CTRL_P = 16, CTRL_Q = 17, 
+    CTRL_R = 18, CTRL_S = 19, CTRL_U = 21, CTRL_X = 24, CTRL_Y = 25, CTRL_Z = 26, ESC = 27, 
+    FORWARD_DELETE =  127, CTRL_H = 8,
+    // The following are just soft codes, not really reported by the
+    // terminal directly.
+    ARROW_LEFT = 1000, ARROW_RIGHT, ARROW_UP, ARROW_DOWN, DEL_KEY, HOME_KEY,
+    END_KEY, PAGE_UP, PAGE_DOWN
 };
 
 void editorSetStatusMessage(const char *fmt, ...);
@@ -174,15 +156,15 @@ char *C_HL_keywords[] = {
 /* python */
 char *PY_HL_extensions[] = {".py","python",NULL};
 char *PY_HL_keywords[] = {
-    "def","if","while","for","break","return","continue","else","elif",
-    "True","False","class","and","as","assert","del","except","except:",
-    "finally","finally:", "from","global","import","in","is","lambda",
-    "nonlocal","not","or","pass","raise","return","try:","try","with",
-    "yeild",
-    /* Python types */
-    "int|","str|","unicode|","dict|","float|","repr|","long|","eval|",
-    "tuple|","list|","set|","frozenset|","chr|","unichr|","ord|","hex|",
-    "oct|","complex|",NULL
+       "def","if","while","for","break","return","continue","else","elif",
+       "True","False","class","and","as","assert","del","except","except:",
+       "finally","finally:", "from","global","import","in","is","lambda",
+       "nonlocal","not","or","pass","raise","return","try:","try","with",
+       "yeild",
+       /* Python types */
+       "int|","str|","unicode|","dict|","float|","repr|","long|","eval|",
+       "tuple|","list|","set|","frozenset|","chr|","unichr|","ord|","hex|",
+       "oct|","complex|",NULL
 };
 
 /* Here we define an array of syntax highlights by extensions, keywords,
@@ -1113,6 +1095,7 @@ void editorMoveCursor(int key) {
     erow *row = (filerow >= E.numrows) ? NULL : &E.row[filerow];
 
     switch(key) {
+    case CTRL_L:
     case ARROW_LEFT:
         if (E.cx == 0) {
             if (E.coloff) {
@@ -1131,6 +1114,7 @@ void editorMoveCursor(int key) {
             E.cx -= 1;
         }
         break;
+    case CTRL_R:
     case ARROW_RIGHT:
         if (row && filecol < row->size) {
             if (E.cx == E.screencols-1) {
@@ -1148,6 +1132,7 @@ void editorMoveCursor(int key) {
             }
         }
         break;
+    case CTRL_U:
     case ARROW_UP:
         if (E.cy == 0) {
             if (E.rowoff) E.rowoff--;
@@ -1155,6 +1140,7 @@ void editorMoveCursor(int key) {
             E.cy -= 1;
         }
         break;
+    case CTRL_D:
     case ARROW_DOWN:
         if (filerow < E.numrows) {
             if (E.cy == E.screenrows-1) {
@@ -1238,17 +1224,17 @@ void editorProcessKeypress(int fd) {
         }
         break;
 
-    case CTRL_K:
-    case CTRL_J:
-    
     case ARROW_UP:
     case ARROW_DOWN:
     case ARROW_LEFT:
     case ARROW_RIGHT:
+    case CTRL_J:
+    case CTRL_K:
+    case CTRL_U:
+    case CTRL_D:
+    case CTRL_L:
+    case CTRL_R:
         editorMoveCursor(c);
-        break;
-    case CTRL_L: /* ctrl+l, clear screen */
-        /* Just refresht the line as side effect. */
         break;
     case ESC:
         /* Nothing to do for ESC in this mode. */

--- a/kilo.c
+++ b/kilo.c
@@ -114,9 +114,11 @@ enum KEY_ACTION{
         CTRL_D = 4,         /* Ctrl-d */
         CTRL_F = 6,         /* Ctrl-f */
         CTRL_H = 8,         /* Ctrl-h */
-        TAB = 9,            /* Tab */
+        TAB    = 9,            /* Tab */
+        CTRL_J = 10,        /* Ctrl-j */
+        CTRL_K = 11,        /* Ctrl-k */
         CTRL_L = 12,        /* Ctrl+l */
-        ENTER = 13,         /* Enter */
+        ENTER  = 13,         /* Enter */
         CTRL_Q = 17,        /* Ctrl-q */
         CTRL_S = 19,        /* Ctrl-s */
         CTRL_U = 21,        /* Ctrl-u */
@@ -172,15 +174,15 @@ char *C_HL_keywords[] = {
 /* python */
 char *PY_HL_extensions[] = {".py","python",NULL};
 char *PY_HL_keywords[] = {
-	"def","if","while","for","break","return","continue","else","elif",
-	"True","False","class","and","as","assert","del","except","except:",
-	"finally","finally:", "from","global","import","in","is","lambda",
-	"nonlocal","not","or","pass","raise","return","try:","try","with",
-	"yeild",
-	/* Python types */
-	"int|","str|","unicode|","dict|","float|","repr|","long|","eval|",
-	"tuple|","list|","set|","frozenset|","chr|","unichr|","ord|","hex|",
-	"oct|","complex|",NULL
+    "def","if","while","for","break","return","continue","else","elif",
+    "True","False","class","and","as","assert","del","except","except:",
+    "finally","finally:", "from","global","import","in","is","lambda",
+    "nonlocal","not","or","pass","raise","return","try:","try","with",
+    "yeild",
+    /* Python types */
+    "int|","str|","unicode|","dict|","float|","repr|","long|","eval|",
+    "tuple|","list|","set|","frozenset|","chr|","unichr|","ord|","hex|",
+    "oct|","complex|",NULL
 };
 
 /* Here we define an array of syntax highlights by extensions, keywords,
@@ -1162,6 +1164,12 @@ void editorMoveCursor(int key) {
             }
         }
         break;
+    case CTRL_J:
+        E.cx = 0;
+        break;
+    case CTRL_K:
+        E.cx = E.screencols-1;
+        break;
     }
     /* Fix cx if the current line has not enough chars. */
     filerow = E.rowoff+E.cy;
@@ -1230,6 +1238,9 @@ void editorProcessKeypress(int fd) {
         }
         break;
 
+    case CTRL_K:
+    case CTRL_J:
+    
     case ARROW_UP:
     case ARROW_DOWN:
     case ARROW_LEFT:


### PR DESCRIPTION
Java syntax highlighting added. Previously, kilo would not resize as the window was changed. Signal handler added to deal with this, however it is not async-safe yet. Will handle masking and changing called print functions to a safe write.

I appreciate the advice. Haven't had to use git for anything more than basic push/pull so far. I tried to squash previous commits with `git rebase -i HEAD~3` If it's still not properly squashed I'll read up more on it tomorrow`